### PR TITLE
RTDT-6998 Pallet tracking with general model	

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->
+
+### Basic Info
+
+| Info                  | Please fill out this column      |
+| --------------------- | -------------------------------- |
+| Platform tested on    | mlgpu  |
+| Ticket                |                             |
+
+### Description of contribution
+
+Reason for change:
+
+
+Changes in this PR:

--- a/configs/label_studio/ls_coco_detection.yml
+++ b/configs/label_studio/ls_coco_detection.yml
@@ -6,9 +6,9 @@ ignore_tags:
   pallets_annotated: ['pallet', 'pallet_bulk', 'pallet_off_ground', 'pallet_on_forks'] 
   # vehicles_annotated: ['amr', 'forklift', ...]  # ussage
 
-crowd_suppress_classes:
-  pallet_bulk: ['pallet', 'pallet_on_forks']
-  pallet_off_ground: ['pallet', 'pallet_on_forks']
+suppress_classes:
+  # in pallet_bulk area we suppress ['pallet', 'pallet_off_ground']
+  pallet_bulk: ['pallet', 'pallet_off_ground']
 
 evaluator:
   type: CocoEvaluator

--- a/configs/label_studio/ls_coco_detection.yml
+++ b/configs/label_studio/ls_coco_detection.yml
@@ -1,5 +1,15 @@
 task: detection
 
+# Top-level — shared with CocoDetection via __share__, resolved names→IDs, passed to criterion via solver
+ignore_tags:
+  # classes present here will be ignored in loss if pallets_annotated == False
+  pallets_annotated: ['pallet', 'pallet_bulk', 'pallet_off_ground', 'pallet_on_forks'] 
+  # vehicles_annotated: ['amr', 'forklift', ...]  # ussage
+
+crowd_suppress_classes:
+  pallet_bulk: ['pallet', 'pallet_on_forks']
+  pallet_off_ground: ['pallet', 'pallet_on_forks']
+
 evaluator:
   type: CocoEvaluator
   iou_types: ['bbox', ]

--- a/engine/data/dataset/coco_dataset.py
+++ b/engine/data/dataset/coco_dataset.py
@@ -28,12 +28,17 @@ __all__ = ['CocoDetection']
 @register()
 class CocoDetection(torchvision.datasets.CocoDetection, DetDataset):
     __inject__ = ['transforms', ]
-    __share__ = ['remap_mscoco_category']
+    __share__ = ['remap_mscoco_category', 'ignore_tags', 'crowd_suppress_classes']
 
-    def __init__(self, img_folder, ann_file, transforms, return_masks=False, remap_mscoco_category=False):
+    def __init__(self, img_folder, ann_file, transforms, return_masks=False, remap_mscoco_category=False, ignore_tags=None, crowd_suppress_classes=None):
         super(CocoDetection, self).__init__(img_folder, ann_file)
         self._transforms = transforms
-        self.prepare = ConvertCocoPolysToMask(return_masks)
+        self.ignore_tags_cfg = ignore_tags or {}
+
+        self.prepare = ConvertCocoPolysToMask(
+            return_masks,
+            ignore_tag_names=list(self.ignore_tags_cfg.keys())
+        )
         self.img_folder = img_folder
         self.ann_file = ann_file
         self.return_masks = return_masks
@@ -44,6 +49,29 @@ class CocoDetection(torchvision.datasets.CocoDetection, DetDataset):
             id_ for id_ in self.coco.getImgIds()
             if os.path.exists(os.path.join(self.root, self.coco.loadImgs(id_)[0]['file_name']))
         ]
+        
+        # Resolve ignore class names -> category IDs for ignore_tags
+        cat_name2id = {cat['name']: cat['id'] for cat in self.categories}
+
+        self.ignore_tags_resolved = {}
+        for tag_name, class_names in self.ignore_tags_cfg.items():
+            unknown = [n for n in class_names if n not in cat_name2id]
+            if unknown:
+                print(f"Warning: ignore_tags classes {unknown} not found in dataset categories")
+            self.ignore_tags_resolved[tag_name] = [cat_name2id[n] for n in class_names if n in cat_name2id]
+
+        # Resolve crowd class names -> category IDs for crowd_suppress_classes
+        crowd_suppress_cfg = crowd_suppress_classes or {}
+        self.crowd_suppress_classes_resolved = {}
+        for crowd_name, suppress_names in crowd_suppress_cfg.items():
+            if crowd_name not in cat_name2id:
+                print(f"Warning: crowd_suppress_classes key '{crowd_name}' not found in dataset categories")
+                continue
+            unknown = [n for n in suppress_names if n not in cat_name2id]
+            if unknown:
+                print(f"Warning: crowd_suppress_classes values {unknown} not found in dataset categories")
+            crowd_id = cat_name2id[crowd_name]
+            self.crowd_suppress_classes_resolved[crowd_id] = [cat_name2id[n] for n in suppress_names if n in cat_name2id]
 
     def __getitem__(self, idx):
         img, target = self.load_item(idx)
@@ -115,8 +143,9 @@ def convert_coco_poly_to_mask(segmentations, height, width):
 
 
 class ConvertCocoPolysToMask(object):
-    def __init__(self, return_masks=False):
+    def __init__(self, return_masks=False, ignore_tag_names=None):
         self.return_masks = return_masks
+        self.ignore_tag_names = ignore_tag_names or []
 
     def __call__(self, image: Image.Image, target, **kwargs):
         w, h = image.size
@@ -126,7 +155,8 @@ class ConvertCocoPolysToMask(object):
 
         anno = target["annotations"]
 
-        anno = [obj for obj in anno if 'iscrowd' not in obj or obj['iscrowd'] == 0]
+        # Keep all annotations including iscrowd — crowd filtering handled in criterion
+        anno = [obj for obj in anno if obj.get('iscrowd', 0) in (0, 1)]
 
         boxes = [obj["bbox"] for obj in anno]
         # guard against no boxes via resizing
@@ -174,12 +204,20 @@ class ConvertCocoPolysToMask(object):
 
         # for conversion to coco api
         area = torch.tensor([obj["area"] for obj in anno])
-        iscrowd = torch.tensor([obj["iscrowd"] if "iscrowd" in obj else 0 for obj in anno])
+        iscrowd = torch.tensor([obj.get("iscrowd", 0) for obj in anno])
         target["area"] = area[keep]
         target["iscrowd"] = iscrowd[keep]
 
         target["orig_size"] = torch.as_tensor([int(w), int(h)])
         # target["size"] = torch.as_tensor([int(w), int(h)])
+
+        # Extract ignore tag fields (image-level flags from annotations)
+        for tag_name in self.ignore_tag_names:
+            if anno and tag_name in anno[0]:
+                tag_val = int(anno[0][tag_name]) # all annos on image have same value
+            else:
+                tag_val = 0  # default: tag missing = NOT annotated (suppress FP)
+            target[tag_name] = torch.tensor(tag_val, dtype=torch.int64)  # 0-dim scalar
 
         return image, target
 

--- a/engine/data/dataset/coco_dataset.py
+++ b/engine/data/dataset/coco_dataset.py
@@ -212,7 +212,7 @@ class ConvertCocoPolysToMask(object):
 
         # for conversion to coco api
         area = torch.tensor([obj["area"] for obj in anno])
-        iscrowd = torch.tensor([obj.get("iscrowd", 0) for obj in anno])
+        iscrowd = torch.tensor([obj["iscrowd"] if "iscrowd" in obj else 0 for obj in anno])
         target["area"] = area[keep]
         target["iscrowd"] = iscrowd[keep]
 

--- a/engine/data/dataset/coco_dataset.py
+++ b/engine/data/dataset/coco_dataset.py
@@ -28,9 +28,18 @@ __all__ = ['CocoDetection']
 @register()
 class CocoDetection(torchvision.datasets.CocoDetection, DetDataset):
     __inject__ = ['transforms', ]
-    __share__ = ['remap_mscoco_category', 'ignore_tags', 'crowd_suppress_classes']
+    __share__ = ['remap_mscoco_category', 'ignore_tags', 'suppress_classes']
 
-    def __init__(self, img_folder, ann_file, transforms, return_masks=False, remap_mscoco_category=False, ignore_tags=None, crowd_suppress_classes=None):
+    def __init__(
+        self, 
+        img_folder, 
+        ann_file, 
+        transforms, 
+        return_masks=False, 
+        remap_mscoco_category=False, 
+        ignore_tags=None, 
+        suppress_classes=None
+    ):
         super(CocoDetection, self).__init__(img_folder, ann_file)
         self._transforms = transforms
         self.ignore_tags_cfg = ignore_tags or {}
@@ -60,18 +69,18 @@ class CocoDetection(torchvision.datasets.CocoDetection, DetDataset):
                 print(f"Warning: ignore_tags classes {unknown} not found in dataset categories")
             self.ignore_tags_resolved[tag_name] = [cat_name2id[n] for n in class_names if n in cat_name2id]
 
-        # Resolve crowd class names -> category IDs for crowd_suppress_classes
-        crowd_suppress_cfg = crowd_suppress_classes or {}
-        self.crowd_suppress_classes_resolved = {}
-        for crowd_name, suppress_names in crowd_suppress_cfg.items():
-            if crowd_name not in cat_name2id:
-                print(f"Warning: crowd_suppress_classes key '{crowd_name}' not found in dataset categories")
+        # Resolve suppress class names -> category IDs for suppress_classes
+        suppress_cfg = suppress_classes or {}
+        self.suppress_classes_resolved = {}
+        for source_name, suppress_names in suppress_cfg.items():
+            if source_name not in cat_name2id:
+                print(f"Warning: suppress_classes key '{source_name}' not found in dataset categories")
                 continue
             unknown = [n for n in suppress_names if n not in cat_name2id]
             if unknown:
-                print(f"Warning: crowd_suppress_classes values {unknown} not found in dataset categories")
-            crowd_id = cat_name2id[crowd_name]
-            self.crowd_suppress_classes_resolved[crowd_id] = [cat_name2id[n] for n in suppress_names if n in cat_name2id]
+                print(f"Warning: suppress_classes values {unknown} not found in dataset categories")
+            source_id = cat_name2id[source_name]
+            self.suppress_classes_resolved[source_id] = [cat_name2id[n] for n in suppress_names if n in cat_name2id]
 
     def __getitem__(self, idx):
         img, target = self.load_item(idx)
@@ -156,7 +165,7 @@ class ConvertCocoPolysToMask(object):
         anno = target["annotations"]
 
         # Keep all annotations including iscrowd — crowd filtering handled in criterion
-        anno = [obj for obj in anno if obj.get('iscrowd', 0) in (0, 1)]
+        anno = [obj for obj in anno if 'iscrowd' not in obj or obj['iscrowd'] == 0]
 
         boxes = [obj["bbox"] for obj in anno]
         # guard against no boxes via resizing

--- a/engine/data/dataset/coco_dataset.py
+++ b/engine/data/dataset/coco_dataset.py
@@ -164,7 +164,6 @@ class ConvertCocoPolysToMask(object):
 
         anno = target["annotations"]
 
-        # Keep all annotations including iscrowd — crowd filtering handled in criterion
         anno = [obj for obj in anno if 'iscrowd' not in obj or obj['iscrowd'] == 0]
 
         boxes = [obj["bbox"] for obj in anno]

--- a/engine/deim/box_ops.py
+++ b/engine/deim/box_ops.py
@@ -38,6 +38,20 @@ def box_iou(boxes1: Tensor, boxes2: Tensor):
     iou = inter / union
     return iou, union
 
+def box_iof(boxes1: Tensor, boxes2: Tensor):
+    """
+    Intersection over First — intersection divided by area of boxes1.
+    Returns 1.0 when boxes1 is fully inside boxes2, regardless of size difference.
+    """
+    area1 = box_area(boxes1)
+    
+    lt = torch.max(boxes1[:, None, :2], boxes2[:, :2])  # [N,M,2]
+    rb = torch.min(boxes1[:, None, 2:], boxes2[:, 2:])  # [N,M,2]
+
+    wh = (rb - lt).clamp(min=0)  # [N,M,2]
+    inter = wh[:, :, 0] * wh[:, :, 1]  # [N,M]
+    
+    return inter / area1[:, None].clamp(min=1e-6)
 
 def generalized_box_iou(boxes1, boxes2):
     """

--- a/engine/deim/deim_criterion.py
+++ b/engine/deim/deim_criterion.py
@@ -81,7 +81,7 @@ class DEIMCriterion(nn.Module):
         target = F.one_hot(target_classes, num_classes=self.num_classes+1)[..., :-1]
         loss = torchvision.ops.sigmoid_focal_loss(src_logits, target, self.alpha, self.gamma, reduction='none')
         
-        # Apply custom suppresions for crowd and ignore classes
+        # Apply custom suppressions for suppress-classes and ignore tags
         loss = self._apply_custom_suppresion(loss, outputs, indices, idx, src_logits)
 
         loss = loss.mean(1).sum() * src_logits.shape[1] / num_boxes
@@ -115,7 +115,7 @@ class DEIMCriterion(nn.Module):
 
         loss = F.binary_cross_entropy_with_logits(src_logits, target_score, weight=weight, reduction='none')
         
-        # Apply custom suppresions for crowd and ignore classes
+        # Apply custom suppressions for suppress-classes and ignore tags
         loss = self._apply_custom_suppresion(loss, outputs, indices, idx, src_logits)
 
         loss = loss.mean(1).sum() * src_logits.shape[1] / num_boxes
@@ -153,7 +153,7 @@ class DEIMCriterion(nn.Module):
         # print(" ### DEIM-gamma{}-alpha{} ### ".format(self.gamma, self.mal_alpha))
         loss = F.binary_cross_entropy_with_logits(src_logits, target_score, weight=weight, reduction='none')
 
-        # Apply custom suppresions for crowd and ignore classes
+        # Apply custom suppressions for suppress-classes and ignore tags
         loss = self._apply_custom_suppresion(loss, outputs, indices, idx, src_logits)
         
         loss = loss.mean(1).sum() * src_logits.shape[1] / num_boxes
@@ -272,22 +272,22 @@ class DEIMCriterion(nn.Module):
         self._ignore_tag_mask = None 
 
     def _apply_custom_suppresion(self, loss, outputs, indices, idx, src_logits):
-        """Apply crowd and ignore-tag FP suppression to classification loss.
+        """Apply suppress-classes and ignore-tag FP suppression to classification loss.
 
         Two independent suppression mechanisms are applied sequentially:
-        1. Crowd suppression: zeros out loss for unmatched predictions that overlap
-        (IoU > 0.5) with iscrowd regions, only for class IDs specified in
-        crowd_suppress_classes config.
-        2. Ignore-tag suppression: zeros out loss for unmatched predictions on
-        classes that were not annotated on this image (e.g. pallets_annotated=false
-        suppresses all pallet-related class losses).
+        1. Suppress-classes: zeros out loss for unmatched predictions that overlap
+           (IoF > 0.5) with suppress-source regions (e.g. pallet_bulk zones),
+           only for class IDs specified in suppress_classes config.
+        2. Ignore-tag: zeros out loss for unmatched predictions on classes that
+           were not annotated on this image (e.g. pallets_annotated=false suppresses
+           all pallet-related class losses).
 
         Both only affect unmatched queries — matched predictions keep their full loss.
 
         Args:
             loss (Tensor): Classification loss tensor [bs, num_queries, num_classes].
             outputs (dict): Model outputs containing 'pred_boxes' [bs, num_queries, 4]
-                used for IoU computation with crowd boxes.
+                used for IoF computation with suppress-source boxes.
             indices (list[tuple]): Hungarian matching result — list of (pred_idx, target_idx)
                 tuples per batch element.
             idx (tuple): Permuted source indices (batch_idx, query_idx) from
@@ -299,15 +299,15 @@ class DEIMCriterion(nn.Module):
             Tensor: Modified loss with suppressed entries zeroed out,
                 same shape [bs, num_queries, num_classes].
         """
-        # Suppress FP penalty for unmatched predictions overlapping crowd regions
+        # Suppress FP penalty for unmatched predictions overlapping suppress-source regions
         if self._suppress_source_targets is not None and self.suppress_classes:
             suppress_mask = self._get_suppress_mask(outputs, self._suppress_source_targets, indices)
             loss = loss * (~suppress_mask).float()
 
         # Suppress FP for classes not annotated on this image (ignore tags)
         if (
-            self._ignore_tag_mask is not None 
-            and self._ignore_tag_mask.shape[-1] == src_logits.shape[-1] 
+            self._ignore_tag_mask is not None
+            and self._ignore_tag_mask.shape[-1] == src_logits.shape[-1]
             and self.ignore_tags_resolved
         ):
             ignore_mask = self._ignore_tag_mask.unsqueeze(1)  # [bs, 1, num_classes]
@@ -318,46 +318,45 @@ class DEIMCriterion(nn.Module):
 
         return loss
 
-
-    def _get_crowd_suppression_mask(self, outputs, crowd_targets, indices):
-        """Mask [bs, num_queries, num_classes] for unmatched predictions overlapping crowd regions.
-        These predictions should NOT be penalized as false positives in cls loss.
+    def _get_suppress_mask(self, outputs, suppress_source_targets, indices):
+        """Mask [bs, num_queries, num_classes] — suppress FP cls loss for unmatched
+        predictions overlapping suppress-source areas (e.g. pallet_bulk zones).
         """
         bs, num_queries, num_classes = outputs['pred_logits'].shape
         device = outputs['pred_logits'].device
         suppress = torch.zeros(bs, num_queries, num_classes, dtype=torch.bool, device=device)
 
-        # Build set of matched predictions (already assigned to non-crowd targets)
+        # Build set of matched predictions
         matched = torch.zeros(bs, num_queries, dtype=torch.bool, device=device)
         for i, (src_idx, _) in enumerate(indices):
             matched[i, src_idx] = True
 
-        for i, ct in enumerate(crowd_targets):
-            if len(ct['boxes']) == 0:
+        for i, st in enumerate(suppress_source_targets):
+            if len(st['boxes']) == 0:
                 continue
-            
+
             pred_boxes = box_cxcywh_to_xyxy(outputs['pred_boxes'][i])
-            crowd_boxes = box_cxcywh_to_xyxy(ct['boxes'])
-            iof_matrix = box_iof(pred_boxes, crowd_boxes)
-            
-            # Unmatched querries overlapping ANY crowd box (IoF > 0.5)
+            source_boxes = box_cxcywh_to_xyxy(st['boxes'])
+            iof_matrix = box_iof(pred_boxes, source_boxes)
+
+            # Unmatched queries overlapping ANY suppress-source box (IoF > 0.5)
             max_iof = iof_matrix.max(dim=1)[0]
             overlapping = (~matched[i]) & (max_iof > 0.5)
-            
+
             if not overlapping.any():
                 continue
-            
-            # Collect suppressed class IDs from all crowd boxes on this image
+
+            # Collect suppressed class IDs from all suppress-source boxes on this image
             suppress_cls = set()
-            for j in range(len(ct["boxes"])):
-                crowd_label = ct["labels"][j].item()
-                if crowd_label in self.crowd_suppress_classes:
-                    suppress_cls.update(self.crowd_suppress_classes[crowd_label])
-                    
+            for j in range(len(st['boxes'])):
+                label = st['labels'][j].item()
+                if label in self.suppress_classes:
+                    suppress_cls.update(self.suppress_classes[label])
+
             for cls_id in suppress_cls:
                 suppress[i, overlapping, cls_id] = True
-        
-        return suppress # [bs, num_queries, num_classes]
+
+        return suppress
 
     def _get_ignore_tag_mask(self, targets):
         """Build [bs, num_classes] mask — True = suppress FP loss for this class/image.
@@ -399,7 +398,7 @@ class DEIMCriterion(nn.Module):
              targets: list of dicts, such that len(targets) == batch_size.
                       The expected keys in each dict depends on the losses applied, see each loss' doc
         """
-        # Split crowd and non-crowd targets; only non-crowd participate in matching/loss
+        # Split targets: suppress-source classes excluded from matching/loss
         suppress_source_ids = set(self.suppress_classes.keys()) if self.suppress_classes else set()
         filtered_targets, suppress_source_targets = filter_suppress_source_targets(targets, suppress_source_ids)
         outputs_without_aux = {k: v for k, v in outputs.items() if 'aux' not in k}
@@ -435,7 +434,7 @@ class DEIMCriterion(nn.Module):
             assert 'aux_outputs' in outputs, ''
 
         # Compute the average number of target boxes accross all nodes, for normalization purposes
-        # Only count non-crowd targets
+        # Only count non-suppress-source targets
         num_boxes = sum(len(t["labels"]) for t in filtered_targets)
         num_boxes = torch.as_tensor([num_boxes], dtype=torch.float, device=next(iter(outputs.values())).device)
         if is_dist_available_and_initialized():

--- a/engine/deim/deim_criterion.py
+++ b/engine/deim/deim_criterion.py
@@ -16,6 +16,7 @@ import copy
 
 from .dfine_utils import bbox2distance
 from .box_ops import box_cxcywh_to_xyxy, box_iou, generalized_box_iou
+from .utils import filter_crowd_targets
 from ..misc.dist_utils import get_world_size, is_dist_available_and_initialized
 from ..core import register
 
@@ -65,6 +66,10 @@ class DEIMCriterion(nn.Module):
         self.mal_alpha = mal_alpha
         self.use_uni_set = use_uni_set
 
+        # Filled by solver from dataset-resolved configs (class names → IDs)
+        self.crowd_suppress_classes = {}  # {crowd_cat_id: [suppress_cat_ids]}
+        self.ignore_tags_resolved = {}    # {tag_name: [cat_ids]}
+
     def loss_labels_focal(self, outputs, targets, indices, num_boxes):
         assert 'pred_logits' in outputs
         src_logits = outputs['pred_logits']
@@ -75,6 +80,10 @@ class DEIMCriterion(nn.Module):
         target_classes[idx] = target_classes_o
         target = F.one_hot(target_classes, num_classes=self.num_classes+1)[..., :-1]
         loss = torchvision.ops.sigmoid_focal_loss(src_logits, target, self.alpha, self.gamma, reduction='none')
+        
+        # Apply custom suppresions for crowd and ignore classes
+        loss = self._apply_custom_suppresion(loss, outputs, indices, idx, src_logits)
+
         loss = loss.mean(1).sum() * src_logits.shape[1] / num_boxes
 
         return {'loss_focal': loss}
@@ -105,6 +114,10 @@ class DEIMCriterion(nn.Module):
         weight = self.alpha * pred_score.pow(self.gamma) * (1 - target) + target_score
 
         loss = F.binary_cross_entropy_with_logits(src_logits, target_score, weight=weight, reduction='none')
+        
+        # Apply custom suppresions for crowd and ignore classes
+        loss = self._apply_custom_suppresion(loss, outputs, indices, idx, src_logits)
+
         loss = loss.mean(1).sum() * src_logits.shape[1] / num_boxes
         return {'loss_vfl': loss}
 
@@ -139,6 +152,10 @@ class DEIMCriterion(nn.Module):
 
         # print(" ### DEIM-gamma{}-alpha{} ### ".format(self.gamma, self.mal_alpha))
         loss = F.binary_cross_entropy_with_logits(src_logits, target_score, weight=weight, reduction='none')
+
+        # Apply custom suppresions for crowd and ignore classes
+        loss = self._apply_custom_suppresion(loss, outputs, indices, idx, src_logits)
+        
         loss = loss.mean(1).sum() * src_logits.shape[1] / num_boxes
         return {'loss_mal': loss}
 
@@ -251,6 +268,118 @@ class DEIMCriterion(nn.Module):
         self.fgl_targets, self.fgl_targets_dn = None, None
         self.own_targets, self.own_targets_dn = None, None
         self.num_pos, self.num_neg = None, None
+        self._crowd_targets = None
+        self._ignore_tag_mask = None 
+
+    def _apply_custom_suppresion(self, loss, outputs, indices, idx, src_logits):
+        """Apply crowd and ignore-tag FP suppression to classification loss.
+
+        Two independent suppression mechanisms are applied sequentially:
+        1. Crowd suppression: zeros out loss for unmatched predictions that overlap
+        (IoU > 0.5) with iscrowd regions, only for class IDs specified in
+        crowd_suppress_classes config.
+        2. Ignore-tag suppression: zeros out loss for unmatched predictions on
+        classes that were not annotated on this image (e.g. pallets_annotated=false
+        suppresses all pallet-related class losses).
+
+        Both only affect unmatched queries — matched predictions keep their full loss.
+
+        Args:
+            loss (Tensor): Classification loss tensor [bs, num_queries, num_classes].
+            outputs (dict): Model outputs containing 'pred_boxes' [bs, num_queries, 4]
+                used for IoU computation with crowd boxes.
+            indices (list[tuple]): Hungarian matching result — list of (pred_idx, target_idx)
+                tuples per batch element.
+            idx (tuple): Permuted source indices (batch_idx, query_idx) from
+                _get_src_permutation_idx(indices), identifying matched queries.
+            src_logits (Tensor): Predicted logits [bs, num_queries, num_classes],
+                used for shape/device reference.
+
+        Returns:
+            Tensor: Modified loss with suppressed entries zeroed out,
+                same shape [bs, num_queries, num_classes].
+        """
+        # Suppress FP penalty for unmatched predictions overlapping crowd regions
+        if self._crowd_targets is not None and self.crowd_suppress_classes:
+            crowd_mask = self._get_crowd_suppression_mask(outputs, self._crowd_targets, indices)
+            loss = loss * (~crowd_mask).float()
+
+        # Suppress FP for classes not annotated on this image (ignore tags)
+        if (
+            self._ignore_tag_mask is not None 
+            and self._ignore_tag_mask.shape[-1] == src_logits.shape[-1] 
+            and self.ignore_tags_resolved
+        ):
+            ignore_mask = self._ignore_tag_mask.unsqueeze(1)  # [bs, 1, num_classes]
+            matched_queries = torch.zeros(src_logits.shape[:2], dtype=torch.bool, device=src_logits.device)
+            matched_queries[idx] = True
+            unmatched = ~matched_queries.unsqueeze(-1)  # [bs, num_queries, 1]
+            loss = loss * (~(ignore_mask & unmatched)).float()
+
+        return loss
+
+
+    def _get_crowd_suppression_mask(self, outputs, crowd_targets, indices):
+        """Mask [bs, num_queries, num_classes] for unmatched predictions overlapping crowd regions.
+        These predictions should NOT be penalized as false positives in cls loss.
+        """
+        bs, num_queries, num_classes = outputs['pred_logits'].shape
+        device = outputs['pred_logits'].device
+        suppress = torch.zeros(bs, num_queries, num_classes, dtype=torch.bool, device=device)
+
+        # Build set of matched predictions (already assigned to non-crowd targets)
+        matched = torch.zeros(bs, num_queries, dtype=torch.bool, device=device)
+        for i, (src_idx, _) in enumerate(indices):
+            matched[i, src_idx] = True
+
+        for i, ct in enumerate(crowd_targets):
+            if len(ct['boxes']) == 0:
+                continue
+            
+            pred_boxes = box_cxcywh_to_xyxy(outputs['pred_boxes'][i])
+            crowd_boxes = box_cxcywh_to_xyxy(ct['boxes'])
+            iou_matrix, _ = box_iou(pred_boxes, crowd_boxes)
+            
+            # Unmatched querries overlapping ANY crowd box (IoU > 0.5)
+            max_iou = iou_matrix.max(dim=1)[0]
+            overlapping = (~matched[i]) & (max_iou > 0.5)
+            
+            if not overlapping.any():
+                continue
+            
+            # Collect suppressed class IDs from all crowd boxes on this image
+            suppress_cls = set()
+            for j in range(len(ct["boxes"])):
+                crowd_label = ct["labels"][j].item()
+                if crowd_label in self.crowd_suppress_classes:
+                    suppress_cls.update(self.crowd_suppress_classes[crowd_label])
+                    
+            for cls_id in suppress_cls:
+                suppress[i, overlapping, cls_id] = True
+        
+        return suppress # [bs, num_queries, num_classes]
+
+    def _get_ignore_tag_mask(self, targets):
+        """Build [bs, num_classes] mask — True = suppress FP loss for this class/image.
+        When a tag (e.g. pallets_annotated) is false/missing for an image, all associated
+        class IDs have their FP classification loss zeroed on that image.
+        """
+        bs = len(targets)
+        device = targets[0]['labels'].device
+        mask = torch.zeros(bs, self.num_classes, dtype=torch.bool, device=device)
+        
+        for tag_name, class_ids in self.ignore_tags_resolved.items():
+            valid_ids = [c for c in class_ids if c < self.num_classes]
+            if not valid_ids:
+                print(f"Warning! No valid ids for ignore tag in {self.ignore_tags_resolved=}")
+                continue
+            
+            cls_tensor = torch.tensor(valid_ids, device=device)
+            for i, t in enumerate(targets):
+                if tag_name in t and t[tag_name].item() == 0: # tag=false -> suppress
+                    mask[i, cls_tensor] = True
+
+        return mask if mask.any() else None
 
     def get_loss(self, loss, outputs, targets, indices, num_boxes, **kwargs):
         loss_map = {
@@ -270,11 +399,15 @@ class DEIMCriterion(nn.Module):
              targets: list of dicts, such that len(targets) == batch_size.
                       The expected keys in each dict depends on the losses applied, see each loss' doc
         """
+        # Split crowd and non-crowd targets; only non-crowd participate in matching/loss
+        filtered_targets, crowd_targets = filter_crowd_targets(targets)
         outputs_without_aux = {k: v for k, v in outputs.items() if 'aux' not in k}
 
         # Retrieve the matching between the outputs of the last layer and the targets
-        indices = self.matcher(outputs_without_aux, targets)['indices']
+        indices = self.matcher(outputs_without_aux, filtered_targets)['indices']
         self._clear_cache()
+        self._crowd_targets = crowd_targets  # restore after _clear_cache
+        self._ignore_tag_mask = self._get_ignore_tag_mask(targets)  # original targets, not filtered
 
         # Get the matching union set across all decoder layers.
         if 'aux_outputs' in outputs:
@@ -283,11 +416,11 @@ class DEIMCriterion(nn.Module):
             if 'pre_outputs' in outputs:
                 aux_outputs_list = outputs['aux_outputs'] + [outputs['pre_outputs']]
             for i, aux_outputs in enumerate(aux_outputs_list):
-                indices_aux = self.matcher(aux_outputs, targets)['indices']
+                indices_aux = self.matcher(aux_outputs, filtered_targets)['indices']
                 cached_indices.append(indices_aux)
                 indices_aux_list.append(indices_aux)
             for i, aux_outputs in enumerate(outputs['enc_aux_outputs']):
-                indices_enc = self.matcher(aux_outputs, targets)['indices']
+                indices_enc = self.matcher(aux_outputs, filtered_targets)['indices']
                 cached_indices_enc.append(indices_enc)
                 indices_aux_list.append(indices_enc)
             indices_go = self._get_go_indices(indices, indices_aux_list)
@@ -301,7 +434,8 @@ class DEIMCriterion(nn.Module):
             assert 'aux_outputs' in outputs, ''
 
         # Compute the average number of target boxes accross all nodes, for normalization purposes
-        num_boxes = sum(len(t["labels"]) for t in targets)
+        # Only count non-crowd targets
+        num_boxes = sum(len(t["labels"]) for t in filtered_targets)
         num_boxes = torch.as_tensor([num_boxes], dtype=torch.float, device=next(iter(outputs.values())).device)
         if is_dist_available_and_initialized():
             torch.distributed.all_reduce(num_boxes)
@@ -314,8 +448,8 @@ class DEIMCriterion(nn.Module):
             use_uni_set = self.use_uni_set and (loss in ['boxes', 'local'])
             indices_in = indices_go if use_uni_set else indices
             num_boxes_in = num_boxes_go if use_uni_set else num_boxes
-            meta = self.get_loss_meta_info(loss, outputs, targets, indices_in)
-            l_dict = self.get_loss(loss, outputs, targets, indices_in, num_boxes_in, **meta)
+            meta = self.get_loss_meta_info(loss, outputs, filtered_targets, indices_in)
+            l_dict = self.get_loss(loss, outputs, filtered_targets, indices_in, num_boxes_in, **meta)
             l_dict = {k: l_dict[k] * self.weight_dict[k] for k in l_dict if k in self.weight_dict}
             losses.update(l_dict)
 
@@ -329,8 +463,8 @@ class DEIMCriterion(nn.Module):
                     use_uni_set = self.use_uni_set and (loss in ['boxes', 'local'])
                     indices_in = indices_go if use_uni_set else cached_indices[i]
                     num_boxes_in = num_boxes_go if use_uni_set else num_boxes
-                    meta = self.get_loss_meta_info(loss, aux_outputs, targets, indices_in)
-                    l_dict = self.get_loss(loss, aux_outputs, targets, indices_in, num_boxes_in, **meta)
+                    meta = self.get_loss_meta_info(loss, aux_outputs, filtered_targets, indices_in)
+                    l_dict = self.get_loss(loss, aux_outputs, filtered_targets, indices_in, num_boxes_in, **meta)
 
                     l_dict = {k: l_dict[k] * self.weight_dict[k] for k in l_dict if k in self.weight_dict}
                     l_dict = {k + f'_aux_{i}': v for k, v in l_dict.items()}
@@ -344,8 +478,8 @@ class DEIMCriterion(nn.Module):
                 use_uni_set = self.use_uni_set and (loss in ['boxes', 'local'])
                 indices_in = indices_go if use_uni_set else cached_indices[-1]
                 num_boxes_in = num_boxes_go if use_uni_set else num_boxes
-                meta = self.get_loss_meta_info(loss, aux_outputs, targets, indices_in)
-                l_dict = self.get_loss(loss, aux_outputs, targets, indices_in, num_boxes_in, **meta)
+                meta = self.get_loss_meta_info(loss, aux_outputs, filtered_targets, indices_in)
+                l_dict = self.get_loss(loss, aux_outputs, filtered_targets, indices_in, num_boxes_in, **meta)
 
                 l_dict = {k: l_dict[k] * self.weight_dict[k] for k in l_dict if k in self.weight_dict}
                 l_dict = {k + '_pre': v for k, v in l_dict.items()}
@@ -358,11 +492,11 @@ class DEIMCriterion(nn.Module):
             if class_agnostic:
                 orig_num_classes = self.num_classes
                 self.num_classes = 1
-                enc_targets = copy.deepcopy(targets)
+                enc_targets = copy.deepcopy(filtered_targets)
                 for t in enc_targets:
                     t['labels'] = torch.zeros_like(t["labels"])
             else:
-                enc_targets = targets
+                enc_targets = filtered_targets
 
             for i, aux_outputs in enumerate(outputs['enc_aux_outputs']):
                 for loss in self.losses:
@@ -382,7 +516,7 @@ class DEIMCriterion(nn.Module):
         # In case of cdn auxiliary losses.
         if 'dn_outputs' in outputs:
             assert 'dn_meta' in outputs, ''
-            indices_dn = self.get_cdn_matched_indices(outputs['dn_meta'], targets)
+            indices_dn = self.get_cdn_matched_indices(outputs['dn_meta'], filtered_targets)
             dn_num_boxes = num_boxes * outputs['dn_meta']['dn_num_group']
 
             for i, aux_outputs in enumerate(outputs['dn_outputs']):
@@ -390,8 +524,8 @@ class DEIMCriterion(nn.Module):
                     aux_outputs['is_dn'] = True
                     aux_outputs['up'], aux_outputs['reg_scale'] = outputs['up'], outputs['reg_scale']
                 for loss in self.losses:
-                    meta = self.get_loss_meta_info(loss, aux_outputs, targets, indices_dn)
-                    l_dict = self.get_loss(loss, aux_outputs, targets, indices_dn, dn_num_boxes, **meta)
+                    meta = self.get_loss_meta_info(loss, aux_outputs, filtered_targets, indices_dn)
+                    l_dict = self.get_loss(loss, aux_outputs, filtered_targets, indices_dn, dn_num_boxes, **meta)
                     l_dict = {k: l_dict[k] * self.weight_dict[k] for k in l_dict if k in self.weight_dict}
                     l_dict = {k + f'_dn_{i}': v for k, v in l_dict.items()}
                     losses.update(l_dict)
@@ -400,8 +534,8 @@ class DEIMCriterion(nn.Module):
             if 'dn_pre_outputs' in outputs:
                 aux_outputs = outputs['dn_pre_outputs']
                 for loss in self.losses:
-                    meta = self.get_loss_meta_info(loss, aux_outputs, targets, indices_dn)
-                    l_dict = self.get_loss(loss, aux_outputs, targets, indices_dn, dn_num_boxes, **meta)
+                    meta = self.get_loss_meta_info(loss, aux_outputs, filtered_targets, indices_dn)
+                    l_dict = self.get_loss(loss, aux_outputs, filtered_targets, indices_dn, dn_num_boxes, **meta)
                     l_dict = {k: l_dict[k] * self.weight_dict[k] for k in l_dict if k in self.weight_dict}
                     l_dict = {k + '_dn_pre': v for k, v in l_dict.items()}
                     losses.update(l_dict)

--- a/engine/deim/deim_criterion.py
+++ b/engine/deim/deim_criterion.py
@@ -15,8 +15,8 @@ import torchvision
 import copy
 
 from .dfine_utils import bbox2distance
-from .box_ops import box_cxcywh_to_xyxy, box_iou, generalized_box_iou
-from .utils import filter_crowd_targets
+from .box_ops import box_cxcywh_to_xyxy, box_iou, box_iof, generalized_box_iou
+from .utils import filter_suppress_source_targets
 from ..misc.dist_utils import get_world_size, is_dist_available_and_initialized
 from ..core import register
 
@@ -67,7 +67,7 @@ class DEIMCriterion(nn.Module):
         self.use_uni_set = use_uni_set
 
         # Filled by solver from dataset-resolved configs (class names → IDs)
-        self.crowd_suppress_classes = {}  # {crowd_cat_id: [suppress_cat_ids]}
+        self.suppress_classes = {}  # {cat_id: [suppress_cat_ids]}
         self.ignore_tags_resolved = {}    # {tag_name: [cat_ids]}
 
     def loss_labels_focal(self, outputs, targets, indices, num_boxes):
@@ -268,7 +268,7 @@ class DEIMCriterion(nn.Module):
         self.fgl_targets, self.fgl_targets_dn = None, None
         self.own_targets, self.own_targets_dn = None, None
         self.num_pos, self.num_neg = None, None
-        self._crowd_targets = None
+        self._suppress_source_targets = None
         self._ignore_tag_mask = None 
 
     def _apply_custom_suppresion(self, loss, outputs, indices, idx, src_logits):
@@ -300,9 +300,9 @@ class DEIMCriterion(nn.Module):
                 same shape [bs, num_queries, num_classes].
         """
         # Suppress FP penalty for unmatched predictions overlapping crowd regions
-        if self._crowd_targets is not None and self.crowd_suppress_classes:
-            crowd_mask = self._get_crowd_suppression_mask(outputs, self._crowd_targets, indices)
-            loss = loss * (~crowd_mask).float()
+        if self._suppress_source_targets is not None and self.suppress_classes:
+            suppress_mask = self._get_suppress_mask(outputs, self._suppress_source_targets, indices)
+            loss = loss * (~suppress_mask).float()
 
         # Suppress FP for classes not annotated on this image (ignore tags)
         if (
@@ -338,11 +338,11 @@ class DEIMCriterion(nn.Module):
             
             pred_boxes = box_cxcywh_to_xyxy(outputs['pred_boxes'][i])
             crowd_boxes = box_cxcywh_to_xyxy(ct['boxes'])
-            iou_matrix, _ = box_iou(pred_boxes, crowd_boxes)
+            iof_matrix = box_iof(pred_boxes, crowd_boxes)
             
-            # Unmatched querries overlapping ANY crowd box (IoU > 0.5)
-            max_iou = iou_matrix.max(dim=1)[0]
-            overlapping = (~matched[i]) & (max_iou > 0.5)
+            # Unmatched querries overlapping ANY crowd box (IoF > 0.5)
+            max_iof = iof_matrix.max(dim=1)[0]
+            overlapping = (~matched[i]) & (max_iof > 0.5)
             
             if not overlapping.any():
                 continue
@@ -400,13 +400,14 @@ class DEIMCriterion(nn.Module):
                       The expected keys in each dict depends on the losses applied, see each loss' doc
         """
         # Split crowd and non-crowd targets; only non-crowd participate in matching/loss
-        filtered_targets, crowd_targets = filter_crowd_targets(targets)
+        suppress_source_ids = set(self.suppress_classes.keys()) if self.suppress_classes else set()
+        filtered_targets, suppress_source_targets = filter_suppress_source_targets(targets, suppress_source_ids)
         outputs_without_aux = {k: v for k, v in outputs.items() if 'aux' not in k}
 
         # Retrieve the matching between the outputs of the last layer and the targets
         indices = self.matcher(outputs_without_aux, filtered_targets)['indices']
         self._clear_cache()
-        self._crowd_targets = crowd_targets  # restore after _clear_cache
+        self._suppress_source_targets = suppress_source_targets  # restore after _clear_cache
         self._ignore_tag_mask = self._get_ignore_tag_mask(targets)  # original targets, not filtered
 
         # Get the matching union set across all decoder layers.

--- a/engine/deim/denoising.py
+++ b/engine/deim/denoising.py
@@ -4,7 +4,7 @@ Modifications Copyright (c) 2024 The DEIM Authors. All Rights Reserved.
 
 import torch
 
-from .utils import inverse_sigmoid, filter_crowd_targets
+from .utils import inverse_sigmoid, filter_suppress_source_targets
 from .box_ops import box_cxcywh_to_xyxy, box_xyxy_to_cxcywh
 
 
@@ -15,13 +15,15 @@ def get_contrastive_denoising_training_group(targets,
                                              class_embed,
                                              num_denoising=100,
                                              label_noise_ratio=0.5,
-                                             box_noise_scale=1.0,):
+                                             box_noise_scale=1.0,
+                                             suppress_source_ids=None):
     """cnd"""
     if num_denoising <= 0:
         return None, None, None, None
 
-    # Exclude crowd annotations from denoising queries
-    targets, _ = filter_crowd_targets(targets)
+    # Exclude suppress-source classes (e.g. pallet_bulk) from denoising queries
+    if suppress_source_ids:
+        targets, _ = filter_suppress_source_targets(targets, suppress_source_ids)
 
     num_gts = [len(t['labels']) for t in targets]
     device = targets[0]['labels'].device

--- a/engine/deim/denoising.py
+++ b/engine/deim/denoising.py
@@ -4,7 +4,7 @@ Modifications Copyright (c) 2024 The DEIM Authors. All Rights Reserved.
 
 import torch
 
-from .utils import inverse_sigmoid
+from .utils import inverse_sigmoid, filter_crowd_targets
 from .box_ops import box_cxcywh_to_xyxy, box_xyxy_to_cxcywh
 
 
@@ -19,6 +19,9 @@ def get_contrastive_denoising_training_group(targets,
     """cnd"""
     if num_denoising <= 0:
         return None, None, None, None
+
+    # Exclude crowd annotations from denoising queries
+    targets, _ = filter_crowd_targets(targets)
 
     num_gts = [len(t['labels']) for t in targets]
     device = targets[0]['labels'].device

--- a/engine/deim/dfine_decoder.py
+++ b/engine/deim/dfine_decoder.py
@@ -448,6 +448,7 @@ class DFINETransformer(nn.Module):
         self.eval_spatial_size = eval_spatial_size
         self.aux_loss = aux_loss
         self.reg_max = reg_max
+        self.suppress_source_ids = set()  # filled by solver
 
         assert query_select_method in ('default', 'one2many', 'agnostic'), ''
         assert cross_attn_method in ('default', 'discrete'), ''
@@ -716,6 +717,7 @@ class DFINETransformer(nn.Module):
                     num_denoising=self.num_denoising,
                     label_noise_ratio=self.label_noise_ratio,
                     box_noise_scale=1.0,
+                    suppress_source_ids=self.suppress_source_ids
                     )
         else:
             denoising_logits, denoising_bbox_unact, attn_mask, dn_meta = None, None, None, None

--- a/engine/deim/rtdetrv2_decoder.py
+++ b/engine/deim/rtdetrv2_decoder.py
@@ -337,6 +337,7 @@ class RTDETRTransformerv2(nn.Module):
         self.num_layers = num_layers
         self.eval_spatial_size = eval_spatial_size
         self.aux_loss = aux_loss
+        self.suppress_source_ids = set()  # filled by solver
 
         assert query_select_method in ('default', 'one2many', 'agnostic'), ''
         assert cross_attn_method in ('default', 'discrete'), ''
@@ -578,7 +579,9 @@ class RTDETRTransformerv2(nn.Module):
                     self.denoising_class_embed, 
                     num_denoising=self.num_denoising, 
                     label_noise_ratio=self.label_noise_ratio, 
-                    box_noise_scale=self.box_noise_scale, )
+                    box_noise_scale=self.box_noise_scale, 
+                    suppress_source_ids=self.suppress_source_ids
+                )
         else:
             denoising_logits, denoising_bbox_unact, attn_mask, dn_meta = None, None, None, None
 

--- a/engine/deim/utils.py
+++ b/engine/deim/utils.py
@@ -19,6 +19,35 @@ def inverse_sigmoid(x: torch.Tensor, eps: float=1e-5) -> torch.Tensor:
     return torch.log(x.clip(min=eps) / (1 - x).clip(min=eps))
 
 
+def filter_crowd_targets(targets):
+    """Split targets into non-crowd and crowd-only dicts.
+
+    Returns:
+        filtered_targets: list of dicts with iscrowd==0 annotations only
+        crowd_targets: list of dicts with iscrowd==1 annotations only
+    """
+    filtered, crowd_only = [], []
+    for t in targets:
+        if 'iscrowd' not in t:
+            filtered.append(t)
+            crowd_only.append({k: v[:0] if isinstance(v, torch.Tensor) and v.dim() > 0 else v
+                              for k, v in t.items()})
+            continue
+        mask = t['iscrowd'] == 0
+        crowd_mask = ~mask
+        ft, ct = {}, {}
+        for k, v in t.items():
+            if isinstance(v, torch.Tensor) and v.dim() > 0 and v.shape[0] == mask.shape[0]:
+                ft[k] = v[mask]
+                ct[k] = v[crowd_mask]
+            else:
+                ft[k] = v
+                ct[k] = v
+        filtered.append(ft)
+        crowd_only.append(ct)
+    return filtered, crowd_only
+
+
 def bias_init_with_prob(prior_prob=0.01):
     """initialize conv/fc bias value according to a given probability value."""
     bias_init = float(-math.log((1 - prior_prob) / prior_prob))

--- a/engine/deim/utils.py
+++ b/engine/deim/utils.py
@@ -19,34 +19,40 @@ def inverse_sigmoid(x: torch.Tensor, eps: float=1e-5) -> torch.Tensor:
     return torch.log(x.clip(min=eps) / (1 - x).clip(min=eps))
 
 
-def filter_crowd_targets(targets):
-    """Split targets into non-crowd and crowd-only dicts.
+def filter_suppress_source_targets(targets, suppress_source_ids):
+    """Split targets into main and suppress-source targets.
+
+    Args:
+        targets: list of target dicts
+        suppress_source_ids: set of category IDs that are suppress sources (e.g. pallet_bulk)
 
     Returns:
-        filtered_targets: list of dicts with iscrowd==0 annotations only
-        crowd_targets: list of dicts with iscrowd==1 annotations only
+        main_targets: without suppress-source annotations
+        source_targets: only suppress-source annotations
     """
-    filtered, crowd_only = [], []
+    if not suppress_source_ids:
+        empty = [{k: v[:0] if isinstance(v, torch.Tensor) and v.dim() > 0 else v
+                  for k, v in t.items()} for t in targets]
+        return targets, empty
+
+    main, sources = [], []
     for t in targets:
-        if 'iscrowd' not in t:
-            filtered.append(t)
-            crowd_only.append({k: v[:0] if isinstance(v, torch.Tensor) and v.dim() > 0 else v
-                              for k, v in t.items()})
-            continue
-        mask = t['iscrowd'] == 0
-        crowd_mask = ~mask
-        ft, ct = {}, {}
+        mask = torch.tensor(
+            [lab.item() not in suppress_source_ids for lab in t['labels']],
+            dtype=torch.bool
+        )
+        source_mask = ~mask
+        mt, st = {}, {}
         for k, v in t.items():
             if isinstance(v, torch.Tensor) and v.dim() > 0 and v.shape[0] == mask.shape[0]:
-                ft[k] = v[mask]
-                ct[k] = v[crowd_mask]
+                mt[k] = v[mask]
+                st[k] = v[source_mask]
             else:
-                ft[k] = v
-                ct[k] = v
-        filtered.append(ft)
-        crowd_only.append(ct)
-    return filtered, crowd_only
-
+                mt[k] = v
+                st[k] = v
+        main.append(mt)
+        sources.append(st)
+    return main, sources
 
 def bias_init_with_prob(prior_prob=0.01):
     """initialize conv/fc bias value according to a given probability value."""

--- a/engine/solver/det_solver.py
+++ b/engine/solver/det_solver.py
@@ -86,9 +86,14 @@ class DetSolver(BaseSolver):
         if hasattr(dataset, 'ignore_tags_resolved'):
             self.criterion.ignore_tags_resolved = dataset.ignore_tags_resolved
             print(f"     ### Ignore tags resolved: {self.criterion.ignore_tags_resolved} ###")
-        if hasattr(dataset, 'crowd_suppress_classes_resolved'):
-            self.criterion.crowd_suppress_classes = dataset.crowd_suppress_classes_resolved
-            print(f"     ### Crowd suppress classes resolved: {self.criterion.crowd_suppress_classes} ###")
+        if hasattr(dataset, 'suppress_classes_resolved'):
+            resolved = dataset.suppress_classes_resolved
+            suppress_source_ids = set(resolved.keys())
+            # Criterion: full mapping {source_id: [suppress_ids]}
+            self.criterion.suppress_classes = resolved
+            # Decoder: set of source IDs for denoising filter
+            self.model.decoder.suppress_source_ids = suppress_source_ids
+            print(f"     ### Suppress classes resolved: {resolved} ###")
 
         for epoch in range(start_epoch, args.epoches):
 

--- a/engine/solver/det_solver.py
+++ b/engine/solver/det_solver.py
@@ -81,6 +81,15 @@ class DetSolver(BaseSolver):
             }
             print(f"     ### GPU Interpolate enabled - scales: {collate_fn.scales} ###")
 
+        # Pass resolved configs from dataset to criterion (names → IDs)
+        dataset = self.train_dataloader.dataset
+        if hasattr(dataset, 'ignore_tags_resolved'):
+            self.criterion.ignore_tags_resolved = dataset.ignore_tags_resolved
+            print(f"     ### Ignore tags resolved: {self.criterion.ignore_tags_resolved} ###")
+        if hasattr(dataset, 'crowd_suppress_classes_resolved'):
+            self.criterion.crowd_suppress_classes = dataset.crowd_suppress_classes_resolved
+            print(f"     ### Crowd suppress classes resolved: {self.criterion.crowd_suppress_classes} ###")
+
         for epoch in range(start_epoch, args.epoches):
 
             self.train_dataloader.set_epoch(epoch)

--- a/engine/solver/det_solver.py
+++ b/engine/solver/det_solver.py
@@ -92,7 +92,8 @@ class DetSolver(BaseSolver):
             # Criterion: full mapping {source_id: [suppress_ids]}
             self.criterion.suppress_classes = resolved
             # Decoder: set of source IDs for denoising filter
-            self.model.decoder.suppress_source_ids = suppress_source_ids
+            model = self.model.module if hasattr(self.model, 'module') else self.model
+            model.decoder.suppress_source_ids = suppress_source_ids
             print(f"     ### Suppress classes resolved: {resolved} ###")
 
         for epoch in range(start_epoch, args.epoches):


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

### Basic Info

| Info                  | Please fill out this column      |
| --------------------- | -------------------------------- |
| Platform tested on    | mlgpu  |
| Ticket                |         [RTDT-6998](https://lvserv01.logivations.com/browse/RTDT-6998)                    |

### Description of contribution
Docs: https://coda.io/d/P-G_dPfiqBFBISN/Pallet-tracking-with-general-model_suPUasq3

Reason for change:
Training pipeline did not support class-based FP suppression and custom annotation tags like pallets_annotated, leading to incorrect FP penalties during training.

Changes in this PR:

- **suppress_classes support**: Suppress-source classes (e.g. pallet_bulk) are excluded from matching, denoising, and loss — the model does not learn to predict them. Unmatched predictions overlapping suppress-source regions have their classification loss suppressed for specified classes (e.g. pallet, pallet_off_ground). Uses IoF (intersection over prediction area) instead of IoU to handle large suppress zones containing small predictions. Configurable via suppress_classes with class names.
- **ignore_tags support**: When a custom annotation tag (e.g. pallets_annotated) is true on an image, classification loss for associated classes is computed normally. When the tag is false or missing, FP classification loss for those classes is suppressed — the model is not penalized for detecting objects that were never annotated. Configurable via ignore_tags with class names.
- **Dynamic name resolution**: Both suppress_classes and ignore_tags configs use class names instead of IDs — resolved dynamically from dataset categories at init time.
