### PR TITLE
RTDT-7655-DEIM--add-nan-quard-for-TopK-layers-in-onnx-file

### DIFF
--- a/engine/deim/dfine_decoder.py
+++ b/engine/deim/dfine_decoder.py
@@ -282,7 +282,7 @@ class LQE(nn.Module):
         prob_topk, _ = prob.topk(self.k, dim=-1)
         stat = torch.cat([prob_topk, prob_topk.mean(dim=-1, keepdim=True)], dim=-1)
         quality_score = self.reg_conf(stat.reshape(B, L, -1))
-        return scores + quality_score
+        return scores + quality_score.nan_to_num(nan=0.0)
 
 
 class TransformerDecoder(nn.Module):
@@ -373,8 +373,10 @@ class TransformerDecoder(nn.Module):
                 pre_scores = score_head[0](output)
                 ref_points_initial = pre_bboxes.detach()
 
-            # Refine bounding box corners using FDR, integrating previous layer's corrections
-            pred_corners = bbox_head[i](output + output_detach) + pred_corners_undetach
+            # Refine bounding box corners using FDR, integrating previous layer's corrections.
+            # Clamp to FP16 range — accumulated corrections can overflow to inf in FP16 inference,
+            # which then causes softmax(inf, ...) = NaN in LQE, corrupting detection scores.
+            pred_corners = (bbox_head[i](output + output_detach) + pred_corners_undetach).clamp(-65504, 65504)
             inter_ref_bbox = distance2bbox(ref_points_initial, integral(pred_corners, project), reg_scale)
 
             if self.training or i == self.eval_idx:

--- a/engine/deim/dfine_decoder.py
+++ b/engine/deim/dfine_decoder.py
@@ -282,7 +282,15 @@ class LQE(nn.Module):
         prob_topk, _ = prob.topk(self.k, dim=-1)
         stat = torch.cat([prob_topk, prob_topk.mean(dim=-1, keepdim=True)], dim=-1)
         quality_score = self.reg_conf(stat.reshape(B, L, -1))
-        return scores + quality_score.nan_to_num(nan=0.0)
+        # NaN-guard for the ONNX/TensorRT path. Avoid torch.nan_to_num: it exports to
+        # IsNaN/IsInf nodes, and TensorRT 8.5.2.2 has no IsInf support (parser fails).
+        # `x != x` is True only for NaN and exports to Equal/Not + Where — all supported by TRT 8.5.
+        quality_score = torch.where(
+            quality_score != quality_score,
+            torch.zeros_like(quality_score),
+            quality_score,
+        )
+        return scores + quality_score
 
 
 class TransformerDecoder(nn.Module):

--- a/make_nvinfer_config.sh
+++ b/make_nvinfer_config.sh
@@ -43,6 +43,8 @@ echo "[property]
 # preprocessing parameters.
 net-scale-factor=0.00392156862
 offsets=0;0;0
+# Integer 0: RGB 1: BGR 2: GRAY
+model-color-format = 0
 
 onnx-file=$ONNX_FILE_NAME
 infer-dims=3;$RES


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

### Basic Info

| Info                  | Please fill out this column      |
| --------------------- | -------------------------------- |
| Platform tested on    | mlgpu  |
| Ticket                |            [RTDT-7655](https://lvserv01.logivations.com/browse/RTDT-7655)                 |

### Description of contribution

Reason for change:
Gst-nvinfer does not support NAN in its pipeline, which is why we occasionally receive frames with no detections. We need to add conversion of NAN values either during model training or after the ONNX file has been generated (if this is required for training).

Changes in this PR:
- `engine/deim/dfine_decoder.py` — Replaced the torch.nan_to_num(nan=0.0) NaN-guard in LQE.forward with torch.where(x != x, 0, x). nan_to_num exports to ONNX as IsNaN/IsInf nodes, and TensorRT 8.5.2.2 does not support IsInf, causing the ONNX parser to fail at the LQE layer (IsInf -> .../lqe_layers.2/Cast_output_0 — plugin not found). The replacement keeps identical NaN→0 semantics but exports to Equal/Not + Where, all supported by TRT 8.5.
- `engine/deim/dfine_decoder.py` — Clamp accumulated pred_corners to the FP16 range [-65504, 65504] to prevent overflow-to-inf during FP16 inference (which previously propagated NaN through the LQE softmax). Exports to a standard Clip op (TRT 8.5-supported).
- `make_nvinfer_config.sh` — Added model-color-format = 0 (RGB) to the generated nvinfer config.
