### PR TITLE
RTDT-7365-Average-metrics-calculation-is-incorrect-in-object-detection-evaluation-script

### DIFF
--- a/engine/data/dataset/coco_eval.py
+++ b/engine/data/dataset/coco_eval.py
@@ -113,6 +113,13 @@ class CustomCOCOEvaluator(COCOeval_faster):
             f"{'Label':<25} {'Num of Ann':<12} {'AR':<10} {'AP':<10} {'f1-score':<10}"
         )
 
+        number_of_valid_annotations = sum(
+            annotation_counts.get(cat_id, 0)
+            for idx, cat_id in enumerate(self.params.catIds)
+            if annotation_counts.get(cat_id, 0) > 0
+            and not np.isnan(f1_scores[idx])
+        )
+
         classes_f1 = []
         classes_map = []
 
@@ -122,13 +129,13 @@ class CustomCOCOEvaluator(COCOeval_faster):
             recall = recalls[idx]
             f1 = f1_scores[idx]
 
-            num_annotations = annotation_counts.get(cat_id, 1)
+            num_annotations = annotation_counts.get(cat_id, 0)
             adjusted_f1 = 0.0
             adjusted_map = 0.0
 
-            if num_annotations != 0:
-                adjusted_f1 = f1 * (num_annotations / number_of_all_annotations)
-                adjusted_map = precision * (num_annotations / number_of_all_annotations)
+            if num_annotations > 0 and not np.isnan(f1):
+                adjusted_f1 = f1 * (num_annotations / number_of_valid_annotations)
+                adjusted_map = precision * (num_annotations / number_of_valid_annotations)
 
             self.print_function(
                 f"{name:<25} "


### PR DESCRIPTION
…nto account)

<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

### Basic Info

| Info                  | Please fill out this column      |
| --------------------- | -------------------------------- |
| Platform tested on    | mlgpu  |
| Ticket                |         https://lvserv01.logivations.com/browse/RTDT-7365                    |

### Description of contribution

Reason for change:
The script that computes object detection metrics (mAP, F1-score) produces average values that are lower than any individual per-class metric, which is mathematically impossible.
Evidence (IoU threshold 0.7):
The per-class F1-scores for classes with actual annotations are: 0.9569, 0.8935, 0.8264, 0.7369, 0.697, 0.6238, 1.0. The lowest valid F1 among these is 0.6238, yet the reported Final F1 Score is 0.5879. Similarly, the lowest valid mAP is 0.5777, but the Final mAP is 0.5794.


Changes in this PR:
Changes have been made to the calculation of metrics (now zero classes are not taken into account), so metrics are displayed more correctly.