### PR TITLE
RTDT-6386-Optimize-DEIM-training-data-loading-pipeline

### DIFF
--- a/configs/label_studio/ls_coco_detection.yml
+++ b/configs/label_studio/ls_coco_detection.yml
@@ -24,6 +24,10 @@ train_dataloader:
     img_folder: /dataset/images
     ann_file: /dataset/annotations/train_coco_annotations.json
     return_masks: False
+    # decode JPEGs directly at reduced size (1/2, 1/4 or 1/8 - whichever keeps
+    # both sides >= presize_res); bboxes are rescaled to match. For 5MP sources
+    # and 512 training res, 768 keeps a ~1.5x quality margin for augmentations.
+    presize_res: 768
     transforms:
       type: Compose
       ops: ~
@@ -40,6 +44,7 @@ val_dataloader:
     img_folder: /dataset/images
     ann_file: /dataset/annotations/val_coco_annotations.json
     return_masks: False
+    presize_res: 768
     transforms:
       type: Compose
       ops: ~ 

--- a/configs/label_studio/ls_dataloader.yml
+++ b/configs/label_studio/ls_dataloader.yml
@@ -27,8 +27,11 @@ train_dataloader:
 
   shuffle: True
   total_batch_size: 32 # total batch size equals to 32 (4 * 8)
-  num_workers: 16
+  # workers auto-scale to the runner: 2/3 of available cores by default;
+  # override the share with num_workers_ratio or pin exactly with num_workers
   pin_memory: True
+  persistent_workers: True  # keep workers alive between epochs (no respawn stall)
+  prefetch_factor: 4
 
 
 val_dataloader:
@@ -39,5 +42,6 @@ val_dataloader:
         - {type: ConvertPILImage, dtype: 'float32', scale: True}
   shuffle: False
   total_batch_size: 64
-  num_workers: 16
   pin_memory: True
+  persistent_workers: True
+  prefetch_factor: 4

--- a/configs/runtime.yml
+++ b/configs/runtime.yml
@@ -2,6 +2,15 @@ print_freq: 100
 output_dir: './logs'
 checkpoint_freq: 12
 
+# Accurate per-stage profiling in tensorboard: inserts torch.cuda.synchronize()
+# before every stage timer in train_one_epoch. Small overhead, truthful
+# attribution. Disable per run with: -u profile_sync=False
+profile_sync: True
+
+# TF32 matmul/conv on Ampere+ GPUs and cuDNN conv autotuning.
+allow_tf32: True
+cudnn_benchmark: True
+
 
 sync_bn: True
 find_unused_parameters: False

--- a/engine/core/_config.py
+++ b/engine/core/_config.py
@@ -75,6 +75,9 @@ class BaseConfig(object):
 
         self.seed :int = None
         self.print_freq :int = None
+        self.profile_sync :bool = True
+        self.allow_tf32 :bool = True
+        self.cudnn_benchmark :bool = True
         self.checkpoint_freq :int = 1
         self.output_dir :str = None
         self.summary_dir :str = None

--- a/engine/data/dataloader.py
+++ b/engine/data/dataloader.py
@@ -33,9 +33,30 @@ __all__ = [
 ]
 
 
+def resolve_num_workers(num_workers=None, num_workers_ratio=2 / 3):
+    """Resolve the worker count from a share of the CPUs available to this
+    process. Runners differ in core count, so configs specify a ratio
+    (default 2/3) instead of a hardcoded number; an explicit `num_workers`
+    in the config still wins.
+    """
+    if num_workers is not None:
+        return num_workers
+    try:
+        cores = len(os.sched_getaffinity(0))  # respects container cpusets
+    except AttributeError:
+        cores = os.cpu_count() or 1
+    resolved = max(1, int(cores * num_workers_ratio))
+    print(f"     ### DataLoader workers: {resolved} ({num_workers_ratio:.2f} of {cores} available cores) ###")
+    return resolved
+
+
 @register()
 class DataLoader(data.DataLoader):
     __inject__ = ['dataset', 'collate_fn']
+
+    def __init__(self, *args, num_workers=None, num_workers_ratio=2 / 3, **kwargs):
+        num_workers = resolve_num_workers(num_workers, num_workers_ratio)
+        super().__init__(*args, num_workers=num_workers, **kwargs)
 
     def __repr__(self) -> str:
         format_string = self.__class__.__name__ + "("
@@ -73,11 +94,17 @@ def batch_image_collate_fn(items):
 
 class BaseCollateFunction(object):
     def set_epoch(self, epoch):
-        self._epoch = epoch
+        # Shared-memory tensor: the collate_fn runs inside DataLoader workers,
+        # which with persistent_workers never re-pickle it — a plain attribute
+        # would go stale there. See DetDataset.set_epoch.
+        if not hasattr(self, '_shared_epoch'):
+            self._shared_epoch = torch.tensor([int(epoch)], dtype=torch.int64).share_memory_()
+        else:
+            self._shared_epoch[0] = int(epoch)
 
     @property
     def epoch(self):
-        return self._epoch if hasattr(self, '_epoch') else -1
+        return int(self._shared_epoch[0]) if hasattr(self, '_shared_epoch') else -1
 
     def __call__(self, items):
         raise NotImplementedError('')

--- a/engine/data/dataset/_dataset.py
+++ b/engine/data/dataset/_dataset.py
@@ -17,8 +17,15 @@ class DetDataset(data.Dataset):
         raise NotImplementedError("Please implement this function to return item before `transforms`.")
 
     def set_epoch(self, epoch) -> None:
-        self._epoch = epoch
+        # Shared-memory tensor: with persistent_workers the DataLoader workers
+        # keep their pickled copy of the dataset alive across epochs, so a plain
+        # attribute set in the main process would never reach them. A shared
+        # tensor is seen by the live workers immediately.
+        if not hasattr(self, '_shared_epoch'):
+            self._shared_epoch = torch.tensor([int(epoch)], dtype=torch.int64).share_memory_()
+        else:
+            self._shared_epoch[0] = int(epoch)
 
     @property
     def epoch(self):
-        return self._epoch if hasattr(self, '_epoch') else -1
+        return int(self._shared_epoch[0]) if hasattr(self, '_shared_epoch') else -1

--- a/engine/data/dataset/coco_dataset.py
+++ b/engine/data/dataset/coco_dataset.py
@@ -31,18 +31,24 @@ class CocoDetection(torchvision.datasets.CocoDetection, DetDataset):
     __share__ = ['remap_mscoco_category', 'ignore_tags', 'suppress_classes']
 
     def __init__(
-        self, 
-        img_folder, 
-        ann_file, 
-        transforms, 
-        return_masks=False, 
-        remap_mscoco_category=False, 
-        ignore_tags=None, 
-        suppress_classes=None
+        self,
+        img_folder,
+        ann_file,
+        transforms,
+        return_masks=False,
+        remap_mscoco_category=False,
+        ignore_tags=None,
+        suppress_classes=None,
+        presize_res=None
     ):
         super(CocoDetection, self).__init__(img_folder, ann_file)
         self._transforms = transforms
         self.ignore_tags_cfg = ignore_tags or {}
+        # JPEG DCT-domain scaled decode: images are decoded directly at 1/2,
+        # 1/4 or 1/8 size (whichever still keeps both sides >= presize_res),
+        # bboxes are rescaled to match. Cuts worker CPU cost of decode and of
+        # the full-resolution augmentations without touching the files on disk.
+        self.presize_res = presize_res
 
         self.prepare = ConvertCocoPolysToMask(
             return_masks,
@@ -88,15 +94,52 @@ class CocoDetection(torchvision.datasets.CocoDetection, DetDataset):
             img, target, _ = self._transforms(img, target, self)
         return img, target
 
+    def _load_image(self, id: int):
+        if self.presize_res:
+            path = os.path.join(self.root, self.coco.loadImgs(id)[0]['file_name'])
+            image = Image.open(path)
+            # libjpeg decodes fewer DCT coefficients -> faster than full decode.
+            # No-op for non-JPEG formats and for images already <= presize_res.
+            image.draft('RGB', (self.presize_res, self.presize_res))
+            return image.convert('RGB')
+        return super(CocoDetection, self)._load_image(id)
+
     def load_item(self, idx):
         image, target = super(CocoDetection, self).__getitem__(idx)
         image_id = self.ids[idx]
+
+        orig_wh = None
+        if self.presize_res:
+            info = self.coco.loadImgs(image_id)[0]
+            orig_wh = (int(info['width']), int(info['height']))
+            sx = image.size[0] / orig_wh[0]
+            sy = image.size[1] / orig_wh[1]
+            if sx != 1.0 or sy != 1.0:
+                # Annotations are in original pixel coords; rescale COPIES to the
+                # decoded size (the dicts belong to the shared COCO index —
+                # mutating them in place would corrupt every following epoch).
+                scaled = []
+                for ann in target:
+                    ann = dict(ann)
+                    x, y, w, h = ann['bbox']
+                    ann['bbox'] = [x * sx, y * sy, w * sx, h * sy]
+                    if 'area' in ann:
+                        ann['area'] = ann['area'] * sx * sy
+                    scaled.append(ann)
+                target = scaled
+
         target = {'image_id': image_id, 'annotations': target}
 
         if self.remap_mscoco_category:
             image, target = self.prepare(image, target, category2label=mscoco_category2label)
         else:
             image, target = self.prepare(image, target)
+
+        if orig_wh is not None:
+            # Keep evaluation in the original pixel space: the postprocessor maps
+            # normalized predictions with orig_size, and the COCO GT used by the
+            # evaluator is in original coordinates.
+            target['orig_size'] = torch.as_tensor(orig_wh)
 
         target['idx'] = torch.tensor([idx])
 

--- a/engine/deim/deim_criterion.py
+++ b/engine/deim/deim_criterion.py
@@ -70,6 +70,11 @@ class DEIMCriterion(nn.Module):
         self.suppress_classes = {}  # {cat_id: [suppress_cat_ids]}
         self.ignore_tags_resolved = {}    # {tag_name: [cat_ids]}
 
+        # Per-step caches for the suppress mask (see _prepare_suppress_cache)
+        self._suppress_lut = None          # [max_src_id+1, num_classes] bool
+        self._suppress_src_boxes = None    # per-image xyxy source boxes
+        self._suppress_cls_mask = None     # [bs, num_classes] bool
+
     def loss_labels_focal(self, outputs, targets, indices, num_boxes):
         assert 'pred_logits' in outputs
         src_logits = outputs['pred_logits']
@@ -251,17 +256,24 @@ class DEIMCriterion(nn.Module):
                         for idx1, idx2 in zip(indices.copy(), indices_aux.copy())]
 
         for ind in [torch.cat([idx[0][:, None], idx[1][:, None]], 1) for idx in indices]:
+            # For each row (query) pick the most frequent (row, col) pair, without
+            # the former per-pair .item() loop that synced GPU->CPU every step.
+            # Ties are broken lexicographically (stable sort over the already
+            # lexicographically sorted output of torch.unique); the old dict loop
+            # relied on an unstable argsort, so its tie-breaks were arbitrary.
             unique, counts = torch.unique(ind, return_counts=True, dim=0)
-            count_sort_indices = torch.argsort(counts, descending=True)
+            count_sort_indices = torch.argsort(counts, descending=True, stable=True)
             unique_sorted = unique[count_sort_indices]
-            column_to_row = {}
-            for idx in unique_sorted:
-                row_idx, col_idx = idx[0].item(), idx[1].item()
-                if row_idx not in column_to_row:
-                    column_to_row[row_idx] = col_idx
-            final_rows = torch.tensor(list(column_to_row.keys()), device=ind.device)
-            final_cols = torch.tensor(list(column_to_row.values()), device=ind.device)
-            results.append((final_rows.long(), final_cols.long()))
+            rows = unique_sorted[:, 0]
+            uniq_rows, inverse = torch.unique(rows, return_inverse=True)
+            first_pos = torch.full((uniq_rows.numel(),), rows.numel(),
+                                   dtype=torch.long, device=ind.device)
+            first_pos.scatter_reduce_(0, inverse,
+                                      torch.arange(rows.numel(), device=ind.device),
+                                      reduce='amin', include_self=True)
+            # ascending first_pos reproduces the old dict-insertion order
+            picked = unique_sorted[first_pos.sort().values]
+            results.append((picked[:, 0].long(), picked[:, 1].long()))
         return results
 
     def _clear_cache(self):
@@ -269,7 +281,9 @@ class DEIMCriterion(nn.Module):
         self.own_targets, self.own_targets_dn = None, None
         self.num_pos, self.num_neg = None, None
         self._suppress_source_targets = None
-        self._ignore_tag_mask = None 
+        self._ignore_tag_mask = None
+        self._suppress_src_boxes = None
+        self._suppress_cls_mask = None
 
     def _apply_custom_suppresion(self, loss, outputs, indices, idx, src_logits):
         """Apply suppress-classes and ignore-tag FP suppression to classification loss.
@@ -318,45 +332,72 @@ class DEIMCriterion(nn.Module):
 
         return loss
 
+    def _prepare_suppress_cache(self, suppress_source_targets):
+        """Precompute the target-derived parts of the suppress mask once per step.
+
+        _get_suppress_mask runs inside every classification-loss call (~8 layer
+        groups per step) but only its prediction-dependent part actually changes
+        per layer. The per-image source boxes and the suppressed-class rows are
+        step constants, and the old per-box `.item()` label loop was a GPU->CPU
+        sync repeated for every layer group.
+        """
+        self._suppress_src_boxes = None
+        self._suppress_cls_mask = None
+        if not self.suppress_classes or not suppress_source_targets:
+            return
+
+        device = suppress_source_targets[0]['labels'].device
+        if self._suppress_lut is None or self._suppress_lut.device != device \
+                or self._suppress_lut.shape[1] != self.num_classes:
+            lut = torch.zeros(max(self.suppress_classes.keys()) + 1, self.num_classes,
+                              dtype=torch.bool, device=device)
+            for src_id, dst_ids in self.suppress_classes.items():
+                valid = [d for d in dst_ids if d < self.num_classes]
+                if valid:
+                    lut[src_id, valid] = True
+            self._suppress_lut = lut
+
+        boxes, cls_rows = [], []
+        empty_row = torch.zeros(self.num_classes, dtype=torch.bool, device=device)
+        for st in suppress_source_targets:
+            if st['boxes'].shape[0] == 0:
+                boxes.append(st['boxes'])
+                cls_rows.append(empty_row)
+            else:
+                boxes.append(box_cxcywh_to_xyxy(st['boxes']))
+                cls_rows.append(self._suppress_lut[st['labels']].any(dim=0))
+        self._suppress_src_boxes = boxes
+        self._suppress_cls_mask = torch.stack(cls_rows)  # [bs, num_classes]
+
     def _get_suppress_mask(self, outputs, suppress_source_targets, indices):
         """Mask [bs, num_queries, num_classes] — suppress FP cls loss for unmatched
         predictions overlapping suppress-source areas (e.g. pallet_bulk zones).
         """
         bs, num_queries, num_classes = outputs['pred_logits'].shape
         device = outputs['pred_logits'].device
-        suppress = torch.zeros(bs, num_queries, num_classes, dtype=torch.bool, device=device)
 
-        # Build set of matched predictions
+        cls_mask = self._suppress_cls_mask
+        if cls_mask is None or cls_mask.shape[-1] != num_classes:
+            # Class count of this head differs from the full one (class-agnostic
+            # encoder branch) — no suppression, matching the old behavior.
+            return torch.zeros(bs, num_queries, num_classes, dtype=torch.bool, device=device)
+
+        # Build set of matched predictions (single scatter, no per-image loop)
         matched = torch.zeros(bs, num_queries, dtype=torch.bool, device=device)
-        for i, (src_idx, _) in enumerate(indices):
-            matched[i, src_idx] = True
+        matched[self._get_src_permutation_idx(indices)] = True
 
-        for i, st in enumerate(suppress_source_targets):
-            if len(st['boxes']) == 0:
+        # Unmatched queries overlapping ANY suppress-source box (IoF > 0.5).
+        # The per-image loop stays (ragged source-box counts) but contains no
+        # `.item()`/`.any()` early-outs, so nothing forces a GPU sync.
+        overlapping = torch.zeros(bs, num_queries, dtype=torch.bool, device=device)
+        for i, source_boxes in enumerate(self._suppress_src_boxes):
+            if source_boxes.shape[0] == 0:
                 continue
-
             pred_boxes = box_cxcywh_to_xyxy(outputs['pred_boxes'][i])
-            source_boxes = box_cxcywh_to_xyxy(st['boxes'])
             iof_matrix = box_iof(pred_boxes, source_boxes)
+            overlapping[i] = (~matched[i]) & (iof_matrix.max(dim=1)[0] > 0.5)
 
-            # Unmatched queries overlapping ANY suppress-source box (IoF > 0.5)
-            max_iof = iof_matrix.max(dim=1)[0]
-            overlapping = (~matched[i]) & (max_iof > 0.5)
-
-            if not overlapping.any():
-                continue
-
-            # Collect suppressed class IDs from all suppress-source boxes on this image
-            suppress_cls = set()
-            for j in range(len(st['boxes'])):
-                label = st['labels'][j].item()
-                if label in self.suppress_classes:
-                    suppress_cls.update(self.suppress_classes[label])
-
-            for cls_id in suppress_cls:
-                suppress[i, overlapping, cls_id] = True
-
-        return suppress
+        return overlapping.unsqueeze(-1) & cls_mask.unsqueeze(1)
 
     def _get_ignore_tag_mask(self, targets):
         """Build [bs, num_classes] mask — True = suppress FP loss for this class/image.
@@ -371,13 +412,20 @@ class DEIMCriterion(nn.Module):
             valid_ids = [c for c in class_ids if c < self.num_classes]
             if not valid_ids:
                 continue
-            
-            cls_tensor = torch.tensor(valid_ids, device=device)
-            for i, t in enumerate(targets):
-                if tag_name in t and t[tag_name].item() == 0: # tag=false -> suppress
-                    mask[i, cls_tensor] = True
 
-        return mask if mask.any() else None
+            cls_tensor = torch.tensor(valid_ids, device=device)
+            # tag=false -> suppress; missing tag -> keep. Vectorized instead of a
+            # per-image .item() loop (one GPU sync per image per step).
+            present = torch.tensor([tag_name in t for t in targets], device=device)
+            one = torch.ones((), dtype=torch.long, device=device)
+            vals = torch.stack([t[tag_name].reshape(()).long() if tag_name in t else one
+                                for t in targets])
+            rows = present & (vals == 0)
+            mask[:, cls_tensor] |= rows.unsqueeze(1)
+
+        # Returned unconditionally: an all-False mask is a no-op downstream, and
+        # the old `mask.any()` early-out was itself a per-step GPU sync.
+        return mask
 
     def get_loss(self, loss, outputs, targets, indices, num_boxes, **kwargs):
         loss_map = {
@@ -407,6 +455,7 @@ class DEIMCriterion(nn.Module):
         self._clear_cache()
         self._suppress_source_targets = suppress_source_targets  # restore after _clear_cache
         self._ignore_tag_mask = self._get_ignore_tag_mask(targets)  # original targets, not filtered
+        self._prepare_suppress_cache(suppress_source_targets)  # step-constant parts of suppress mask
 
         # Get the matching union set across all decoder layers.
         if 'aux_outputs' in outputs:

--- a/engine/deim/utils.py
+++ b/engine/deim/utils.py
@@ -36,12 +36,13 @@ def filter_suppress_source_targets(targets, suppress_source_ids):
         return targets, empty
 
     main, sources = [], []
+    ids = None
     for t in targets:
-        mask = torch.tensor(
-            [lab.item() not in suppress_source_ids for lab in t['labels']],
-            dtype=torch.bool
-        )
-        source_mask = ~mask
+        if ids is None or ids.device != t['labels'].device:
+            ids = torch.as_tensor(sorted(suppress_source_ids),
+                                  dtype=t['labels'].dtype, device=t['labels'].device)
+        source_mask = torch.isin(t['labels'], ids)
+        mask = ~source_mask
         mt, st = {}, {}
         for k, v in t.items():
             if isinstance(v, torch.Tensor) and v.dim() > 0 and v.shape[0] == mask.shape[0]:

--- a/engine/misc/dist_utils.py
+++ b/engine/misc/dist_utils.py
@@ -166,6 +166,8 @@ def warp_loader(loader, shuffle=False):
             collate_fn=loader.collate_fn,
             pin_memory=loader.pin_memory,
             num_workers=loader.num_workers,
+            persistent_workers=loader.persistent_workers,
+            prefetch_factor=loader.prefetch_factor if loader.num_workers > 0 else None,
         )
     return loader
 

--- a/engine/optim/ema.py
+++ b/engine/optim/ema.py
@@ -42,10 +42,12 @@ class ModelEMA(object):
         self.before_start = 0
         self.start = start
         self.updates = 0  # number of EMA updates
+        # Read self.decay (not the captured constructor arg) so runtime changes
+        # like `ema.decay = ema_restart_decay` at stop_epoch actually take effect.
         if warmups == 0:
-            self.decay_fn = lambda x: decay
+            self.decay_fn = lambda x: self.decay
         else:
-            self.decay_fn = lambda x: decay * (1 - math.exp(-x / warmups))  # decay exponential ramp (to help early epochs)
+            self.decay_fn = lambda x: self.decay * (1 - math.exp(-x / warmups))  # decay exponential ramp (to help early epochs)
 
         for p in self.module.parameters():
             p.requires_grad_(False)

--- a/engine/optim/ema.py
+++ b/engine/optim/ema.py
@@ -50,23 +50,38 @@ class ModelEMA(object):
         for p in self.module.parameters():
             p.requires_grad_(False)
 
+        self._cache_model_id = None
+
+    def _build_cache(self, model: nn.Module):
+        # state_dict tensors share storage with the live parameters/buffers, and
+        # both the optimizer and load_state_dict update them in-place, so the
+        # cached references stay valid. The cache is invalidated whenever the
+        # model object changes, the EMA is moved, or a state dict is loaded.
+        msd = dist_utils.de_parallel(model).state_dict()
+        esd = self.module.state_dict()
+        keys = [k for k, v in esd.items() if v.dtype.is_floating_point]
+        assert all(k in msd for k in keys), 'EMA and model state_dict keys diverged'
+        self._ema_tensors = [esd[k] for k in keys]
+        self._model_tensors = [msd[k].detach() for k in keys]
+        self._cache_model_id = id(model)
 
     def update(self, model: nn.Module):
         if self.before_start < self.start:
             self.before_start += 1
             return
-        # Update EMA parameters
+        # Update EMA parameters: ema = d * ema + (1 - d) * model, fused across
+        # all tensors with foreach ops instead of one tiny kernel per tensor.
         with torch.no_grad():
             self.updates += 1
             d = self.decay_fn(self.updates)
-            msd = dist_utils.de_parallel(model).state_dict()
-            for k, v in self.module.state_dict().items():
-                if v.dtype.is_floating_point:
-                    v *= d
-                    v += (1 - d) * msd[k].detach()
+            if self._cache_model_id != id(model):
+                self._build_cache(model)
+            torch._foreach_mul_(self._ema_tensors, d)
+            torch._foreach_add_(self._ema_tensors, self._model_tensors, alpha=1.0 - d)
 
     def to(self, *args, **kwargs):
         self.module = self.module.to(*args, **kwargs)
+        self._cache_model_id = None  # .to() may reallocate storages
         return self
 
     def state_dict(self, ):
@@ -74,6 +89,7 @@ class ModelEMA(object):
 
     def load_state_dict(self, state, strict=True):
         self.module.load_state_dict(state['module'], strict=strict)
+        self._cache_model_id = None
         if 'updates' in state:
             self.updates = state['updates']
 

--- a/engine/solver/_solver.py
+++ b/engine/solver/_solver.py
@@ -44,6 +44,19 @@ class BaseSolver(object):
         else:
             device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
 
+        if torch.cuda.is_available():
+            if cfg.allow_tf32:
+                # TF32 on Ampere+: ~10-bit mantissa fp32 matmul/conv, big speedup.
+                # Criterion runs with autocast disabled, so this affects it directly.
+                torch.backends.cuda.matmul.allow_tf32 = True
+                torch.backends.cudnn.allow_tf32 = True
+                torch.set_float32_matmul_precision('high')
+            if cfg.cudnn_benchmark:
+                # Autotune conv algorithms per input shape. Multiscale training uses
+                # a small fixed set of shapes, so the cache warms up within the first
+                # steps of each shape and stays hot.
+                torch.backends.cudnn.benchmark = True
+
         self.model = cfg.model
 
         # NOTE: Must load_tuning_state before EMA instance building

--- a/engine/solver/det_engine.py
+++ b/engine/solver/det_engine.py
@@ -134,20 +134,30 @@ def train_one_epoch(self_lr_scheduler, lr_scheduler, model: torch.nn.Module, cri
     lr_warmup_scheduler :Warmup = kwargs.get('lr_warmup_scheduler', None)
     gpu_transforms = kwargs.get('gpu_transforms', None)
     multiscale_cfg = kwargs.get('multiscale_cfg', None)  # NEW: GPU multi-scale interpolate
+    profile_sync = kwargs.get('profile_sync', False)
+
+    def _t():
+        # CUDA kernels are async: without a synchronize the timers measure kernel
+        # launch, not execution, and GPU time gets attributed to whatever stage
+        # hits a sync point first. profile_sync=True trades a small overhead for
+        # truthful per-stage attribution.
+        if profile_sync and torch.cuda.is_available():
+            torch.cuda.synchronize()
+        return time.time()
 
     cur_iters = epoch * len(data_loader)
 
     # Structured profiling metrics
     profiling = ProfilingMetrics()
-    t_load_start = time.time()
+    t_load_start = _t()
 
     for i, (samples, targets) in enumerate(metric_logger.log_every(data_loader, print_freq, header)):
         # Measure data loading time
-        t_data_load = time.time() - t_load_start
+        t_data_load = _t() - t_load_start
         profiling.data_load += t_data_load
 
         # Time data transfer to GPU + GPU transforms + interpolate
-        t_transfer_start = time.time()
+        t_transfer_start = _t()
         samples = samples.to(device)
         targets = [{k: v.to(device) for k, v in t.items()} for t in targets]
 
@@ -160,7 +170,7 @@ def train_one_epoch(self_lr_scheduler, lr_scheduler, model: torch.nn.Module, cri
             sz = random.choice(multiscale_cfg['scales'])
             samples = F.interpolate(samples, size=sz)
 
-        t_data_transfer = time.time() - t_transfer_start
+        t_data_transfer = _t() - t_transfer_start
         profiling.data_transfer += t_data_transfer
 
         global_step = epoch * len(data_loader) + i
@@ -168,76 +178,69 @@ def train_one_epoch(self_lr_scheduler, lr_scheduler, model: torch.nn.Module, cri
 
         if scaler is not None:
             # Forward pass with AMP
-            t_forward_start = time.time()
+            t_forward_start = _t()
             with torch.autocast(device_type=str(device), cache_enabled=True):
                 outputs = model(samples, targets=targets)
-            t_forward = time.time() - t_forward_start
+            t_forward = _t() - t_forward_start
             profiling.forward += t_forward
 
-            if torch.isnan(outputs['pred_boxes']).any() or torch.isinf(outputs['pred_boxes']).any():
-                print("NaN or Inf detected")
-                outputs['pred_boxes'] = torch.nan_to_num(outputs['pred_boxes'], nan=0.0)
-                state = model.state_dict()
-                new_state = {'model': {k.replace('module.', ''): v for k, v in state.items()}}
-                dist_utils.save_on_master(new_state, "./NaN.pth")
-
             # Criterion
-            t_criterion_start = time.time()
+            t_criterion_start = _t()
             with torch.autocast(device_type=str(device), enabled=False):
                 loss_dict = criterion(outputs, targets, **metas)
-            t_criterion = time.time() - t_criterion_start
+            t_criterion = _t() - t_criterion_start
             profiling.criterion += t_criterion
             loss = sum(loss_dict.values())
 
             # Backward
-            t_backward_start = time.time()
+            t_backward_start = _t()
             scaler.scale(loss).backward()
             if max_norm > 0:
                 scaler.unscale_(optimizer)
                 torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm)
-            t_backward = time.time() - t_backward_start
+            t_backward = _t() - t_backward_start
             profiling.backward += t_backward
 
             # Optimizer
-            t_optimizer_start = time.time()
+            t_optimizer_start = _t()
             scaler.step(optimizer)
             scaler.update()
             optimizer.zero_grad()
-            t_optimizer = time.time() - t_optimizer_start
+            t_optimizer = _t() - t_optimizer_start
             profiling.optimizer += t_optimizer
 
         else:
             # Forward pass without AMP
-            t_forward_start = time.time()
+            t_forward_start = _t()
             outputs = model(samples, targets=targets)
-            t_forward = time.time() - t_forward_start
+            t_forward = _t() - t_forward_start
             profiling.forward += t_forward
 
             # Criterion
-            t_criterion_start = time.time()
+            t_criterion_start = _t()
             loss_dict = criterion(outputs, targets, **metas)
-            t_criterion = time.time() - t_criterion_start
+            t_criterion = _t() - t_criterion_start
             profiling.criterion += t_criterion
 
             loss: torch.Tensor = sum(loss_dict.values())
             optimizer.zero_grad()
 
             # Backward
-            t_backward_start = time.time()
+            t_backward_start = _t()
             loss.backward()
             if max_norm > 0:
                 torch.nn.utils.clip_grad_norm_(model.parameters(), max_norm)
-            t_backward = time.time() - t_backward_start
+            t_backward = _t() - t_backward_start
             profiling.backward += t_backward
 
             # Optimizer
-            t_optimizer_start = time.time()
+            t_optimizer_start = _t()
             optimizer.step()
-            t_optimizer = time.time() - t_optimizer_start
+            t_optimizer = _t() - t_optimizer_start
             profiling.optimizer += t_optimizer
 
         # Other overhead (EMA, LR scheduling, logging)
-        t_other_start = time.time()
+        t_other_start = _t()
 
         if ema is not None:
             ema.update(model)
@@ -266,12 +269,12 @@ def train_one_epoch(self_lr_scheduler, lr_scheduler, model: torch.nn.Module, cri
             for k, v in loss_dict_reduced.items():
                 writer.add_scalar(f'Loss/{k}', v.item(), global_step)
 
-        t_other = time.time() - t_other_start
+        t_other = _t() - t_other_start
         profiling.other += t_other
         profiling.num_batches += 1
 
         # Reset timer for next batch data loading
-        t_load_start = time.time()
+        t_load_start = _t()
 
     # Gather stats from all processes
     metric_logger.synchronize_between_processes()

--- a/engine/solver/det_solver.py
+++ b/engine/solver/det_solver.py
@@ -119,6 +119,7 @@ class DetSolver(BaseSolver):
                 epoch,
                 max_norm=args.clip_max_norm,
                 print_freq=args.print_freq,
+                profile_sync=args.profile_sync,
                 ema=self.ema,
                 scaler=self.scaler,
                 lr_warmup_scheduler=self.lr_warmup_scheduler,


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

### Basic Info

| Info                  | Please fill out this column      |
| --------------------- | -------------------------------- |
| Platform tested on    | keypoint-tuning (2× Quadro RTX 5000, 8 vCPU), docker `ml_all:LS_dfine_latest` |
| Ticket                | [RTDT-6386](https://lvserv01.logivations.com/browse/RTDT-6386) |

### Description of contribution

Reason for change:

DEIM training takes 30–53h per run and we had no reliable data on where the time goes: the per-stage profiling in `train_one_epoch` used plain `time.time()` without `torch.cuda.synchronize()`, so GPU time was attributed to whichever stage hit a hidden sync point first (the old "Criterion 29%" was largely a measurement artifact). This PR fixes the profiling and applies the optimizations that were validated through a series of isolated experiments (one branch per change, identical dataset/seed/epochs, 6 epochs × 135k images each, results compared via TensorBoard `Profiling/*` scalars).

Changes in this PR:

- **Accurate profiling** (`profile_sync`, default `True`): `torch.cuda.synchronize()` before every stage timer → truthful per-stage attribution in TensorBoard (`Profiling/*`). Can be disabled per run with `-u profile_sync=False`.
- **EMA update via `torch._foreach_*`** with cached tensor lists instead of a Python loop over the full `state_dict` (hundreds of tiny CUDA kernels per step). Verified bit-comparable to the old loop (max abs diff 1.5e-8 after 10 updates).
- **Fixed a latent EMA bug**: `ModelEMA.decay_fn` was a lambda capturing the constructor `decay` value, so the `ema.decay = ema_restart_decay` reassignment at `stop_epoch` ("Refresh EMA") silently never took effect. `decay_fn` now reads `self.decay`. No behavior change for the current config (both values are 0.9999), but the `ema_restart_decay` knob is now actually functional.
- **`persistent_workers: True` + `prefetch_factor: 4`**: workers are no longer respawned every epoch. Epoch counter is propagated into live workers via a shared-memory tensor (required for the augmentation stop-policy, which reads `dataset.epoch` inside workers); `warp_loader` now forwards both kwargs under DDP.
- **Criterion de-synchronization**: removed ~250 hidden GPU→CPU syncs per step (`.item()`/`.any()` loops in `filter_suppress_source_targets`, `_get_ignore_tag_mask`, `_get_suppress_mask`, `_get_go_indices`); target-derived parts of the suppress mask are computed once per step instead of in every classification-loss call (~8×/step). Verified with fixed-seed A/B: per-function exact equality + full `criterion.forward` old-vs-new within 1e-6.
- **TF32 + `cudnn.benchmark`** flags (`allow_tf32`, `cudnn_benchmark`, default on). Note: TF32 is a no-op on Turing GPUs (test machine); expected to help on Ampere+ runners.
- **Removed the per-step NaN/Inf debug check** on `pred_boxes` (a forced GPU sync every step + debug checkpoint dump). The `math.isfinite(loss)` divergence guard remains.
- **Auto-scaled dataloader workers**: `num_workers` is no longer hardcoded; by default 2/3 of the cores available to the process (`os.sched_getaffinity`, respects container cpusets). Override share with `num_workers_ratio` or pin exactly with `num_workers` — runners with different core counts need no manual config edits.
- **JPEG DCT-domain scaled decode** (`presize_res: 768` in the LS config, off by default in code): images are decoded directly at 1/2 (or 1/4, 1/8 — the largest power-of-2 downscale keeping both sides ≥ `presize_res`, chosen per image via `PIL Image.draft`). This is *less* IDCT work, so decode gets ~3–4× cheaper and the `RandomZoomOut` canvas ~4× smaller — the same effect as an offline dataset pre-resize, but with zero changes to the files on disk (datasets are read directly from NFS, so an offline resized copy is not an option). Bboxes/areas are rescaled per image from the *actual* decoded size (copies only — the shared pycocotools index is never mutated); `orig_size` is kept in original pixel space so evaluation against the original-coordinate COCO GT stays correct. Note on the value: 768 guarantees the 1/2 step for 5MP sources (1296×972, a 1.5× margin over the largest 640 multiscale); 1024 would silently disable it (972 < 1024), and anything ≤ ~486 would force upscaling inside the augmentations.

#### Experiment results (6 epochs each, bs=32, seed=0, mean of epochs 1–4, profile_sync on)

| Experiment | Change under test | Avg step | Avg epoch | Final mAP | Verdict |
|---|---|---|---|---|---|
| exp0-baseline | measurement fix only | 0.921 s | 446 s | — | reference; truthful attribution: Backward 39%, Forward 24%, Criterion 20%, DataLoad 1.5% |
| exp1-tf32-nan-gate | TF32 + cudnn.benchmark + NaN gate | 0.917 s | 444 s | — | ≈0 on Turing (TF32 unsupported); kept — expected gain on Ampere+ |
| exp2-ema-foreach | foreach EMA | **0.869 s** | **421 s** | 0.448 | −0.034 s/step in EMA stage (0.039→0.005), clear win |
| exp2.5-draft-decode | JPEG draft decode (`presize_res: 768`) | 0.863 s | 418 s | **0.459** | no mAP degradation; speed ≈ exp2 on this host (DataLoad was already 1.5%) — the win is a 3–4× per-image CPU headroom for weak-CPU/NFS-contended runners |
| exp3-persistent-workers | persistent workers | 0.890 s | 431 s | — | within noise on this host (thermal drift between sequential runs); removes the per-epoch worker respawn stall |
| exp4-criterion-desync | criterion vectorization | 0.907 s | 439 s | — | within noise here — this GPU is compute-bound and `profile_sync` serializes stages, masking overlap gains; expected to matter on faster GPUs |
| exp5-decode-backend | torchvision.io decode | 1.101 s | 533 s | — | **regression, not merged** (see below) |

**TensorBoard — per-stage profiling across experiments:**

Profiling/time_total per epoch, all experiments overlaid:
<img width="3261" height="683" alt="image" src="https://github.com/user-attachments/assets/641ee08c-c823-41b0-87ef-823f8e8a8b18" />


Profiling/time_other (EMA) — exp1 vs exp2 drop 0.039 → 0.005:
<img width="3261" height="683" alt="image" src="https://github.com/user-attachments/assets/22181aa4-952b-4e8a-9153-e32beb421896" />
#### Image decode benchmark (200 real 5MP JPEGs, `tools/benchmark_decode.py` on the experiment branch)

| Backend | Pure decode | Decode + train transforms |
|---|---|---|
| PIL (current) | 36.7 img/s | 5.3 img/s |
| torchvision.io (CPU) | 56.7 img/s (1.55×) | 7.4 img/s |
| torchvision.io (CUDA/nvJPEG) | 70.1 img/s (1.91×) | 59.3 img/s |

Despite winning the standalone benchmark, `torchvision.io` was **slower in real training** (+21% step time, DataLoad 0.013→0.101 s) and was dropped:

- The benchmark ran single-process, where torch tensor ops use **all CPU cores**; DataLoader workers run with `torch.set_num_threads(1)`, and single-threaded tensor augmentations (ZoomOut/IoUCrop/Resize on uint8 CHW) lose to PIL's SIMD implementations.
- The CUDA decode numbers are from an **idle** GPU: in training it would compete with forward/backward for the same device, and CUDA contexts cannot be shared across forked DataLoader workers (decode would have to move to the main process, below the required throughput).

The accepted alternative is the **JPEG draft decode** above (exp2.5): instead of swapping the decode backend, PIL/libjpeg decodes fewer DCT coefficients and returns a half-size image directly — faster than a full decode, keeps the SIMD PIL augmentation path, and needs no dataset copy.

<img width="3261" height="683" alt="image" src="https://github.com/user-attachments/assets/b6328017-8d49-41f6-980e-740dc029866f" />

#### Not included / follow-ups

- Decode backend switch (exp5) — rejected based on the results above; superseded by the draft decode (exp2.5).
- Matcher cost-matrix batching (single `.cpu()` transfer for all 5 Hungarian calls) — deferred; revisit after profiling on a production (Ampere+) runner.
